### PR TITLE
feat: add public order flow

### DIFF
--- a/BackOffice/BackEnd/README.md
+++ b/BackOffice/BackEnd/README.md
@@ -73,6 +73,8 @@ Variables principales:
 - `JWT_SECRET`, `JWT_EXPIRES_IN`.
 - `PORT`, `CORS_ORIGIN`.
 
+En producción agrega la URL del frontend público en `CORS_ORIGIN` (separadas por comas si hay varias) para habilitar CORS.
+
 ### 3. Ejecutar migraciones
 Las migraciones se ejecutan contra la conexión directa (5432):
 ```bash
@@ -154,6 +156,19 @@ npm run test:e2e
 
 # Test coverage
 npm run test:cov
+```
+
+### Probar endpoint público
+
+PowerShell:
+
+```powershell
+$form = @{
+clienteNombre = "Cliente QA"
+clienteTelefono = "1122334455"
+files = Get-Item "C:\ruta\archivo1.pdf", "C:\ruta\archivo2.pdf"
+}
+Invoke-RestMethod -Uri http://localhost:3000/public/orders -Method Post -Form $form
 ```
 
 ## 📝 Scripts Disponibles

--- a/BackOffice/BackEnd/src/app.module.ts
+++ b/BackOffice/BackEnd/src/app.module.ts
@@ -5,6 +5,7 @@ import { OrdersModule } from './orders/orders.module';
 import { EmployeesModule } from './employees/employees.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
+import { PublicOrdersModule } from './public-orders/public-orders.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AuthModule } from './auth/auth.module';
     EmployeesModule,
     AuthModule,
     HealthModule,
+    PublicOrdersModule,
   ],
 })
 export class AppModule {}

--- a/BackOffice/BackEnd/src/orders/orders.controller.ts
+++ b/BackOffice/BackEnd/src/orders/orders.controller.ts
@@ -51,8 +51,7 @@ export class OrdersController {
         const folder = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
         const filename = `${randomUUID()}-${file.originalname}`;
         const path = `orders/${folder}/${filename}`;
-        await this.storageService.uploadFile(file.buffer, path, file.mimetype);
-        const url = this.storageService.getPublicUrl(path);
+        const { url } = await this.storageService.uploadFile(file, path);
         // TODO: usar createSignedUrl si el bucket es privado
         return { nombre: file.originalname, path, url };
       }),

--- a/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
+++ b/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreatePublicOrderDto {
+  @ApiProperty()
+  @IsString()
+  clienteNombre: string;
+
+  @ApiProperty()
+  @IsString()
+  clienteTelefono: string;
+
+  // Solo para documentación; los archivos reales vienen vía multipart
+  @ApiProperty({ type: 'string', format: 'binary', required: false, isArray: true })
+  files?: any;
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
@@ -1,0 +1,66 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  UploadedFiles,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { randomUUID } from 'crypto';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+import { OrdersService } from '../orders/orders.service';
+import { CreatePublicOrderDto } from './dto/create-public-order.dto';
+
+@Controller('public/orders')
+export class PublicOrdersController {
+  constructor(
+    private readonly storageService: SupabaseStorageService,
+    private readonly ordersService: OrdersService,
+  ) {}
+
+  @Post()
+  @UseInterceptors(
+    FilesInterceptor('files', 10, {
+      limits: { fileSize: 15 * 1024 * 1024 },
+    }),
+  )
+  async create(
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body() body: CreatePublicOrderDto,
+  ) {
+    const { clienteNombre, clienteTelefono } = body;
+    if (!clienteNombre || !clienteTelefono) {
+      throw new BadRequestException('Datos incompletos');
+    }
+
+    if (!files || files.length === 0) {
+      throw new BadRequestException('No se subieron archivos');
+    }
+
+    // Validar mimetype
+    for (const file of files) {
+      if (file.mimetype !== 'application/pdf') {
+        throw new BadRequestException('Solo se permiten archivos PDF');
+      }
+    }
+
+    await this.storageService.ensureBucket('orders');
+    const uploaded = [];
+    for (const file of files) {
+      const now = new Date();
+      const path = `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}/${randomUUID()}/${file.originalname}`;
+      const { url } = await this.storageService.uploadFile(file, path);
+      uploaded.push({ nombre: file.originalname, url });
+    }
+
+    const order = await this.ordersService.createOrder({
+      clienteNombre,
+      clienteTelefono,
+      archivos: uploaded,
+      paid: false,
+    });
+
+    return order;
+  }
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PublicOrdersController } from './public-orders.controller';
+import { OrdersModule } from '../orders/orders.module';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+
+@Module({
+  imports: [OrdersModule],
+  controllers: [PublicOrdersController],
+  providers: [SupabaseStorageService],
+})
+export class PublicOrdersModule {}

--- a/ClienteFinal/README.md
+++ b/ClienteFinal/README.md
@@ -129,6 +129,9 @@ npm run build
 ### Variables de Entorno
 
 La aplicación está configurada para desarrollo local por defecto.
+Para apuntar a otra API en desarrollo, edita `src/environments/environment.ts` y ajusta `apiUrl` (por defecto `http://localhost:3000`).
+
+En la pantalla de "Nuevo Pedido", el botón **Enviar pedido** valida los datos, sube los PDFs al backend y muestra la confirmación.
 
 ### Personalización
 

--- a/ClienteFinal/src/app/core/services/orders-public.service.ts
+++ b/ClienteFinal/src/app/core/services/orders-public.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface Pedido {
+  id: string;
+  clienteNombre: string;
+  clienteTelefono: string;
+  archivos: { nombre: string; url: string }[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class OrdersPublicService {
+  constructor(private http: HttpClient) {}
+
+  submitOrder(form: {
+    nombre: string;
+    telefono: string;
+    files: File[];
+  }): Observable<Pedido> {
+    const fd = new FormData();
+    fd.append('clienteNombre', form.nombre);
+    fd.append('clienteTelefono', form.telefono);
+    form.files.forEach(f => fd.append('files', f, f.name));
+    return this.http.post<Pedido>(`${environment.apiUrl}/public/orders`, fd);
+  }
+}

--- a/ClienteFinal/src/app/features/landing/landing.component.ts
+++ b/ClienteFinal/src/app/features/landing/landing.component.ts
@@ -13,6 +13,6 @@ export class LandingComponent {
   constructor(private router: Router) {}
 
   hacerPedido(): void {
-    this.router.navigate(['/pedido']);
+    this.router.navigate(['/nuevo-pedido']);
   }
 }

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
@@ -1,20 +1,45 @@
 <div *ngIf="!enviado; else enviadoTpl">
-  <form (ngSubmit)="enviar()" #form="ngForm">
+  <form (ngSubmit)="enviar()" #form="ngForm" novalidate>
     <label>
       Nombre:
       <input type="text" name="nombre" [(ngModel)]="nombre" required />
     </label>
     <label>
       Teléfono:
-      <input type="tel" name="telefono" [(ngModel)]="telefono" required />
+      <input
+        type="tel"
+        name="telefono"
+        [(ngModel)]="telefono"
+        required
+        pattern="\d{6,20}"
+      />
     </label>
     <label>
       Archivos:
-      <input type="file" (change)="onFileChange($event)" multiple />
+      <input
+        type="file"
+        accept="application/pdf"
+        (change)="onFileChange($event)"
+        multiple
+        required
+      />
     </label>
-    <button type="submit" [disabled]="loading">Enviar</button>
+    <ul>
+      <li *ngFor="let f of archivos">
+        {{ f.name }} ({{ f.size / 1024 / 1024 | number: '1.1-1' }} MB)
+      </li>
+    </ul>
+    <div *ngFor="let err of fileErrors" class="error">{{ err }}</div>
+    <div *ngIf="errorMsg" class="error">{{ errorMsg }}</div>
+    <button
+      type="submit"
+      [disabled]="form.invalid || archivos.length === 0 || fileErrors.length > 0 || loading"
+    >
+      <span *ngIf="!loading">Enviar pedido</span>
+      <span *ngIf="loading">Enviando...</span>
+    </button>
   </form>
 </div>
 <ng-template #enviadoTpl>
-  <p>Pedido enviado</p>
+  <p>¡Pedido enviado! ID: {{ pedidoId }}</p>
 </ng-template>

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
-import { environment } from '../../../environments/environment';
+import { OrdersPublicService } from '../../core/services/orders-public.service';
 
 @Component({
   selector: 'app-nuevo-pedido',
@@ -14,41 +13,52 @@ export class NuevoPedidoComponent {
   nombre = '';
   telefono = '';
   archivos: File[] = [];
+  fileErrors: string[] = [];
   enviado = false;
   loading = false;
+  pedidoId?: string;
+  errorMsg = '';
 
-  constructor(private http: HttpClient) {}
+  constructor(private ordersService: OrdersPublicService) {}
 
   onFileChange(event: Event): void {
     const target = event.target as HTMLInputElement;
-    this.archivos = Array.from(target.files || []);
+    const files = Array.from(target.files || []);
+    this.archivos = [];
+    this.fileErrors = [];
+    files.forEach(f => {
+      if (f.type !== 'application/pdf') {
+        this.fileErrors.push(`${f.name} no es un PDF válido`);
+      } else if (f.size > 15 * 1024 * 1024) {
+        this.fileErrors.push(`${f.name} supera 15MB`);
+      } else {
+        this.archivos.push(f);
+      }
+    });
   }
 
-  async enviar(): Promise<void> {
+  enviar(): void {
     if (!this.nombre || !this.telefono || this.archivos.length === 0) {
       return;
     }
     this.loading = true;
-    try {
-      const formData = new FormData();
-      this.archivos.forEach((f) => formData.append('file', f));
-      const uploaded = await this.http.post<{ nombre: string; path: string; url: string }[]>(
-        `${environment.apiUrl}/orders/upload`,
-        formData
-      ).toPromise();
-      const archivos = uploaded?.map((f) => ({ nombre: f.nombre, url: f.url })) || [];
-      await this.http.post(`${environment.apiUrl}/orders`, {
-        clienteNombre: this.nombre,
-        clienteTelefono: this.telefono,
-        archivos,
-        paid: true,
-      }).toPromise();
-      this.enviado = true;
-      this.nombre = '';
-      this.telefono = '';
-      this.archivos = [];
-    } finally {
-      this.loading = false;
-    }
+    this.errorMsg = '';
+    this.ordersService
+      .submitOrder({ nombre: this.nombre, telefono: this.telefono, files: this.archivos })
+      .subscribe({
+        next: order => {
+          this.enviado = true;
+          this.pedidoId = order.id;
+          this.nombre = '';
+          this.telefono = '';
+          this.archivos = [];
+        },
+        error: () => {
+          this.errorMsg = 'Intenta más tarde';
+        },
+        complete: () => {
+          this.loading = false;
+        },
+      });
   }
 }


### PR DESCRIPTION
## Summary
- add Supabase storage service with public bucket helpers
- expose public `/public/orders` endpoint to upload PDF orders
- wire up client app to submit orders with files and basic validations

## Testing
- `npm test` (backend) *(fails: Multiple configurations found)*
- `npm test` (ClienteFinal) *(fails: No inputs were found in config file tsconfig.spec.json)*
- `npm run build` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68bba09894b0832a9b1e5ee1754376ce