### PR TITLE
feat: add public order flow

### DIFF
--- a/BackOffice/BackEnd/README.md
+++ b/BackOffice/BackEnd/README.md
@@ -73,6 +73,8 @@ Variables principales:
 - `JWT_SECRET`, `JWT_EXPIRES_IN`.
 - `PORT`, `CORS_ORIGIN`.
 
+Para entornos donde el frontend público corre en otro dominio o puerto, agrega ese origen a la variable `CORS_ORIGIN` separando múltiples valores con comas.
+
 ### 3. Ejecutar migraciones
 Las migraciones se ejecutan contra la conexión directa (5432):
 ```bash
@@ -154,6 +156,19 @@ npm run test:e2e
 
 # Test coverage
 npm run test:cov
+```
+
+### Probar endpoint público
+
+Ejemplo en PowerShell para crear un pedido con PDFs:
+
+```powershell
+$form = @{
+  clienteNombre = "Cliente QA"
+  clienteTelefono = "1122334455"
+  files = Get-Item "C:\ruta\archivo1.pdf", "C:\ruta\archivo2.pdf"
+}
+Invoke-RestMethod -Uri http://localhost:3000/public/orders -Method Post -Form $form
 ```
 
 ## 📝 Scripts Disponibles

--- a/BackOffice/BackEnd/package.json
+++ b/BackOffice/BackEnd/package.json
@@ -37,6 +37,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",
+    "uuid": "^9.0.1",
     "multer": "^1.4.5-lts.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/BackOffice/BackEnd/src/app.module.ts
+++ b/BackOffice/BackEnd/src/app.module.ts
@@ -5,6 +5,7 @@ import { OrdersModule } from './orders/orders.module';
 import { EmployeesModule } from './employees/employees.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
+import { PublicOrdersModule } from './public-orders/public-orders.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AuthModule } from './auth/auth.module';
     EmployeesModule,
     AuthModule,
     HealthModule,
+    PublicOrdersModule,
   ],
 })
 export class AppModule {}

--- a/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
+++ b/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreatePublicOrderDto {
+  @ApiProperty({ description: 'Nombre del cliente' })
+  @IsString()
+  clienteNombre: string;
+
+  @ApiProperty({ description: 'Teléfono del cliente' })
+  @IsString()
+  clienteTelefono: string;
+
+  @ApiProperty({
+    description: 'Archivos PDF',
+    type: 'string',
+    format: 'binary',
+    required: false,
+    isArray: true,
+  })
+  files?: any[];
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
@@ -1,0 +1,69 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  UploadedFiles,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { v4 as uuidv4 } from 'uuid';
+import { Express } from 'express';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+import { OrdersService } from '../orders/orders.service';
+import { CreatePublicOrderDto } from './dto/create-public-order.dto';
+
+@Controller('public/orders')
+export class PublicOrdersController {
+  constructor(
+    private readonly storage: SupabaseStorageService,
+    private readonly ordersService: OrdersService,
+  ) {}
+
+  @Post()
+  @UseInterceptors(
+    FilesInterceptor('files', 10, {
+      limits: { fileSize: 15 * 1024 * 1024 },
+    }),
+  )
+  async create(
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body() body: CreatePublicOrderDto,
+  ) {
+    if (!body.clienteNombre || !body.clienteTelefono) {
+      throw new BadRequestException('Nombre y teléfono son requeridos');
+    }
+    if (!files || files.length === 0) {
+      throw new BadRequestException('Debe adjuntar al menos un archivo');
+    }
+    const invalid = files.find((f) => f.mimetype !== 'application/pdf');
+    if (invalid) {
+      throw new BadRequestException('Solo se aceptan archivos PDF');
+    }
+
+    await this.storage.ensureBucket('orders');
+    const today = new Date();
+    const prefix = `${today.getFullYear()}/${(today.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}/${today
+      .getDate()
+      .toString()
+      .padStart(2, '0')}/${uuidv4()}`;
+
+    const archivos = [];
+    for (const file of files) {
+      const path = `${prefix}/${file.originalname}`;
+      const { url } = await this.storage.uploadFile(file, path);
+      archivos.push({ nombre: file.originalname, url });
+    }
+
+    const order = await this.ordersService.createOrder({
+      clienteNombre: body.clienteNombre,
+      clienteTelefono: body.clienteTelefono,
+      archivos,
+      paid: false,
+    });
+
+    return order;
+  }
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OrdersModule } from '../orders/orders.module';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+import { PublicOrdersController } from './public-orders.controller';
+
+@Module({
+  imports: [OrdersModule],
+  controllers: [PublicOrdersController],
+  providers: [SupabaseStorageService],
+})
+export class PublicOrdersModule {}

--- a/BackOffice/BackEnd/src/storage/supabase-storage.service.ts
+++ b/BackOffice/BackEnd/src/storage/supabase-storage.service.ts
@@ -1,43 +1,67 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { Express } from 'express';
 
 @Injectable()
 export class SupabaseStorageService {
   private readonly client: SupabaseClient;
-  private readonly bucket: string;
+  private readonly logger = new Logger(SupabaseStorageService.name);
 
   constructor() {
     const url = process.env.SUPABASE_URL as string;
     const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
-    this.bucket = process.env.SUPABASE_BUCKET || 'orders';
     this.client = createClient(url, serviceKey);
   }
 
+  /**
+   * Ensure a bucket exists and is public. Idempotent.
+   */
+  async ensureBucket(bucket = 'orders'): Promise<void> {
+    const { data: buckets, error } = await this.client.storage.listBuckets();
+    if (error) {
+      this.logger.error('Error listing buckets', error);
+      throw error;
+    }
+    const exists = buckets?.some((b) => b.name === bucket);
+    if (!exists) {
+      const { error: createError } = await this.client.storage.createBucket(
+        bucket,
+        { public: true },
+      );
+      if (createError) {
+        this.logger.error('Error creating bucket', createError);
+        throw createError;
+      }
+    } else {
+      // Ensure bucket is public
+      const { error: updateError } = await this.client.storage.updateBucket(
+        bucket,
+        { public: true },
+      );
+      if (updateError) {
+        this.logger.error('Error updating bucket', updateError);
+        throw updateError;
+      }
+    }
+  }
+
   async uploadFile(
-    buffer: Buffer,
+    file: Express.Multer.File,
     path: string,
-    contentType: string,
-  ): Promise<void> {
+    bucket = 'orders',
+  ): Promise<{ url: string }> {
     const { error } = await this.client.storage
-      .from(this.bucket)
-      .upload(path, buffer, { contentType });
+      .from(bucket)
+      .upload(path, file.buffer, {
+        contentType: file.mimetype,
+        upsert: false,
+      });
     if (error) {
+      this.logger.error('Error uploading file', error);
       throw error;
     }
-  }
-
-  getPublicUrl(path: string): string {
-    const { data } = this.client.storage.from(this.bucket).getPublicUrl(path);
-    return data.publicUrl;
-  }
-
-  async createSignedUrl(path: string, expiresIn: number): Promise<string> {
-    const { data, error } = await this.client.storage
-      .from(this.bucket)
-      .createSignedUrl(path, expiresIn);
-    if (error) {
-      throw error;
-    }
-    return data.signedUrl;
+    const { data } = this.client.storage.from(bucket).getPublicUrl(path);
+    return { url: data.publicUrl };
   }
 }
+

--- a/ClienteFinal/README.md
+++ b/ClienteFinal/README.md
@@ -54,6 +54,8 @@ src/app/
 - Botón CTA para comenzar pedido
 - Diseño atractivo y moderno
 
+En la ruta `/nuevo-pedido` se encuentra un formulario sencillo donde el cliente puede ingresar nombre, teléfono y cargar archivos PDF para enviarlos al backend mediante el botón **Enviar**.
+
 ### 2. Wizard de Pedidos
 
 - **Paso 1**: Selección de archivos con drag & drop
@@ -128,7 +130,7 @@ npm run build
 
 ### Variables de Entorno
 
-La aplicación está configurada para desarrollo local por defecto.
+La aplicación está configurada para desarrollo local por defecto. El endpoint de API se toma de `src/environments/environment.ts` (o de la variable `NG_APP_API_URL`). En desarrollo suele ser `http://localhost:3000`.
 
 ### Personalización
 

--- a/ClienteFinal/src/app/core/services/orders-public.service.ts
+++ b/ClienteFinal/src/app/core/services/orders-public.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface PublicOrder {
+  id: string;
+  clienteNombre: string;
+  clienteTelefono: string;
+  archivos: { nombre: string; url: string }[];
+  estado: string;
+  paid: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrdersPublicService {
+  constructor(private http: HttpClient) {}
+
+  submitOrder(form: {
+    nombre: string;
+    telefono: string;
+    files: File[];
+  }): Observable<PublicOrder> {
+    const fd = new FormData();
+    fd.append('clienteNombre', form.nombre);
+    fd.append('clienteTelefono', form.telefono);
+    form.files.forEach((f) => fd.append('files', f, f.name));
+    return this.http.post<PublicOrder>(
+      `${environment.apiUrl}/public/orders`,
+      fd,
+    );
+  }
+}

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
@@ -6,15 +6,41 @@
     </label>
     <label>
       Teléfono:
-      <input type="tel" name="telefono" [(ngModel)]="telefono" required />
+      <input
+        type="tel"
+        name="telefono"
+        [(ngModel)]="telefono"
+        required
+        pattern="\d{6,20}"
+      />
     </label>
     <label>
       Archivos:
-      <input type="file" (change)="onFileChange($event)" multiple />
+      <input
+        type="file"
+        accept="application/pdf"
+        (change)="onFileChange($event)"
+        multiple
+      />
     </label>
-    <button type="submit" [disabled]="loading">Enviar</button>
+    <ul>
+      <li *ngFor="let f of archivos">{{ f.name }} ({{ formatSize(f.size) }})</li>
+    </ul>
+    <div class="error" *ngFor="let err of fileErrors">{{ err }}</div>
+    <div class="error" *ngIf="errorMsg">{{ errorMsg }}</div>
+    <button
+      type="submit"
+      [disabled]="
+        loading || !form.form.valid || archivos.length === 0 || fileErrors.length > 0
+      "
+    >
+      {{ loading ? 'Enviando...' : 'Enviar pedido' }}
+    </button>
   </form>
 </div>
 <ng-template #enviadoTpl>
-  <p>Pedido enviado</p>
+  <p>
+    ¡Pedido enviado! Número: {{ pedidoId }}
+  </p>
+  <button (click)="reset()">Nuevo pedido</button>
 </ng-template>

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
-import { environment } from '../../../environments/environment';
+import { OrdersPublicService } from '../../core/services/orders-public.service';
 
 @Component({
   selector: 'app-nuevo-pedido',
@@ -14,14 +13,28 @@ export class NuevoPedidoComponent {
   nombre = '';
   telefono = '';
   archivos: File[] = [];
+  fileErrors: string[] = [];
   enviado = false;
   loading = false;
+  pedidoId?: string;
+  errorMsg = '';
 
-  constructor(private http: HttpClient) {}
+  constructor(private ordersService: OrdersPublicService) {}
 
   onFileChange(event: Event): void {
     const target = event.target as HTMLInputElement;
-    this.archivos = Array.from(target.files || []);
+    const selected = Array.from(target.files || []);
+    this.fileErrors = [];
+    this.archivos = [];
+    selected.forEach((f) => {
+      if (f.type !== 'application/pdf') {
+        this.fileErrors.push(`${f.name} no es un PDF válido`);
+      } else if (f.size > 15 * 1024 * 1024) {
+        this.fileErrors.push(`${f.name} supera los 15MB`);
+      } else {
+        this.archivos.push(f);
+      }
+    });
   }
 
   async enviar(): Promise<void> {
@@ -29,26 +42,37 @@ export class NuevoPedidoComponent {
       return;
     }
     this.loading = true;
+    this.errorMsg = '';
     try {
-      const formData = new FormData();
-      this.archivos.forEach((f) => formData.append('file', f));
-      const uploaded = await this.http.post<{ nombre: string; path: string; url: string }[]>(
-        `${environment.apiUrl}/orders/upload`,
-        formData
-      ).toPromise();
-      const archivos = uploaded?.map((f) => ({ nombre: f.nombre, url: f.url })) || [];
-      await this.http.post(`${environment.apiUrl}/orders`, {
-        clienteNombre: this.nombre,
-        clienteTelefono: this.telefono,
-        archivos,
-        paid: true,
-      }).toPromise();
+      const pedido = await this.ordersService
+        .submitOrder({
+          nombre: this.nombre,
+          telefono: this.telefono,
+          files: this.archivos,
+        })
+        .toPromise();
       this.enviado = true;
+      this.pedidoId = pedido?.id;
       this.nombre = '';
       this.telefono = '';
       this.archivos = [];
+    } catch {
+      this.errorMsg = 'Intenta más tarde';
     } finally {
       this.loading = false;
     }
+  }
+
+  formatSize(bytes: number): string {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  }
+
+  reset(): void {
+    this.enviado = false;
+    this.pedidoId = undefined;
   }
 }


### PR DESCRIPTION
## Summary
- allow file uploads to Supabase Storage with bucket bootstrap
- expose public `/public/orders` endpoint for customers
- add frontend service and form for public order creation

## Testing
- `npm test` (backend) *(fails: Multiple configurations found)*
- `npm test` (cliente)` *(fails: TS18003: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68bba09894b0832a9b1e5ee1754376ce