### PR TITLE
feat: enable public order submission

### DIFF
--- a/BackOffice/BackEnd/README.md
+++ b/BackOffice/BackEnd/README.md
@@ -71,7 +71,7 @@ Variables principales:
 - `DATABASE_URL`: conexión al pooler de Supabase (`pgbouncer=true`, puerto 6543, `sslmode=require`) utilizada en tiempo de ejecución.
 - `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`.
 - `JWT_SECRET`, `JWT_EXPIRES_IN`.
-- `PORT`, `CORS_ORIGIN`.
+- `PORT`, `CORS_ORIGIN` (agrega la URL del frontend público si corre en otro puerto).
 
 ### 3. Ejecutar migraciones
 Las migraciones se ejecutan contra la conexión directa (5432):
@@ -217,6 +217,21 @@ Este proyecto es privado y confidencial.
 ## 🆘 Soporte
 
 Para soporte técnico, contactar al equipo de desarrollo.
+
+## 📢 Endpoint público de pedidos
+
+El frontend público puede crear pedidos sin autenticación mediante `POST /public/orders`.
+
+Ejemplo en PowerShell:
+
+```powershell
+$form = @{
+clienteNombre = "Cliente QA"
+clienteTelefono = "1122334455"
+files = Get-Item "C:\ruta\archivo1.pdf", "C:\ruta\archivo2.pdf"
+}
+Invoke-RestMethod -Uri http://localhost:3000/public/orders -Method Post -Form $form
+```
 
 ---
 

--- a/BackOffice/BackEnd/src/app.module.ts
+++ b/BackOffice/BackEnd/src/app.module.ts
@@ -5,6 +5,7 @@ import { OrdersModule } from './orders/orders.module';
 import { EmployeesModule } from './employees/employees.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
+import { PublicOrdersModule } from './public-orders/public-orders.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AuthModule } from './auth/auth.module';
     EmployeesModule,
     AuthModule,
     HealthModule,
+    PublicOrdersModule,
   ],
 })
 export class AppModule {}

--- a/BackOffice/BackEnd/src/orders/orders.controller.ts
+++ b/BackOffice/BackEnd/src/orders/orders.controller.ts
@@ -45,15 +45,16 @@ export class OrdersController {
   )
   @ApiOperation({ summary: 'Subir archivos a Supabase Storage' })
   async uploadFiles(@UploadedFiles() files: Express.Multer.File[]) {
+    await this.storageService.ensureBucket();
     const uploads = await Promise.all(
       files.map(async file => {
         const now = new Date();
-        const folder = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+        const folder = `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(
+          now.getDate(),
+        ).padStart(2, '0')}`;
         const filename = `${randomUUID()}-${file.originalname}`;
-        const path = `orders/${folder}/${filename}`;
-        await this.storageService.uploadFile(file.buffer, path, file.mimetype);
-        const url = this.storageService.getPublicUrl(path);
-        // TODO: usar createSignedUrl si el bucket es privado
+        const path = `${folder}/${filename}`;
+        const { url } = await this.storageService.uploadFile(file, path);
         return { nombre: file.originalname, path, url };
       }),
     );

--- a/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
+++ b/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreatePublicOrderDto {
+  @ApiProperty()
+  @IsString()
+  clienteNombre: string;
+
+  @ApiProperty()
+  @IsString()
+  clienteTelefono: string;
+
+  @ApiProperty({ type: 'string', format: 'binary', required: false, description: 'Archivos PDF', isArray: true })
+  files?: any;
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UploadedFiles,
+  UseInterceptors,
+  BadRequestException,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import { randomUUID } from 'crypto';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+import { OrdersService } from '../orders/orders.service';
+import { CreatePublicOrderDto } from './dto/create-public-order.dto';
+
+@Controller('public/orders')
+export class PublicOrdersController {
+  constructor(
+    private readonly storageService: SupabaseStorageService,
+    private readonly ordersService: OrdersService,
+  ) {}
+
+  @Post()
+  @UseInterceptors(
+    FilesInterceptor('files', 10, {
+      storage: memoryStorage(),
+      limits: { fileSize: 15 * 1024 * 1024 },
+    }),
+  )
+  async create(
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body() body: CreatePublicOrderDto,
+  ) {
+    if (!files?.length) {
+      throw new BadRequestException('Se requiere al menos un archivo');
+    }
+    const invalid = files.find(f => f.mimetype !== 'application/pdf');
+    if (invalid) {
+      throw new BadRequestException('Solo se permiten archivos PDF');
+    }
+    await this.storageService.ensureBucket('orders');
+    const uploads = await Promise.all(
+      files.map(async file => {
+        const now = new Date();
+        const folder = `${now.getFullYear()}/${String(
+          now.getMonth() + 1,
+        ).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}`;
+        const path = `${folder}/${randomUUID()}/${file.originalname}`;
+        const { url } = await this.storageService.uploadFile(file, path);
+        return { nombre: file.originalname, url };
+      }),
+    );
+    const order = await this.ordersService.createOrder({
+      clienteNombre: body.clienteNombre,
+      clienteTelefono: body.clienteTelefono,
+      archivos: uploads,
+      paid: false,
+    });
+    return order;
+  }
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PublicOrdersController } from './public-orders.controller';
+import { OrdersModule } from '../orders/orders.module';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+
+@Module({
+  imports: [OrdersModule],
+  controllers: [PublicOrdersController],
+  providers: [SupabaseStorageService],
+})
+export class PublicOrdersModule {}

--- a/ClienteFinal/README.md
+++ b/ClienteFinal/README.md
@@ -90,6 +90,10 @@ npm start
 npm run build
 ```
 
+### Configurar `environment.ts`
+
+El archivo `src/environments/environment.ts` define `apiUrl`. En desarrollo apunta por defecto a `http://localhost:3000`, ajusta este valor si tu backend corre en otra URL.
+
 ### Comandos Disponibles
 
 - `npm start`: Ejecuta la aplicación en modo desarrollo
@@ -123,6 +127,10 @@ npm run build
 5. **Revisar**: Ve resumen del pedido
 6. **Pagar**: Completa el proceso de pago
 7. **Confirmación**: Recibe confirmación de éxito
+
+## 📬 Enviar pedido
+
+En la sección "Nuevo Pedido" completa tu nombre, teléfono y selecciona uno o más PDFs. El botón **Enviar** sube los archivos al backend y crea un pedido. Si todo sale bien verás el mensaje "¡Pedido enviado!".
 
 ## 🔧 Configuración
 

--- a/ClienteFinal/src/app/core/models/order.model.ts
+++ b/ClienteFinal/src/app/core/models/order.model.ts
@@ -1,0 +1,15 @@
+export interface OrderFile {
+  nombre: string;
+  url: string;
+}
+
+export interface Order {
+  id: string;
+  clienteNombre: string;
+  clienteTelefono: string;
+  archivos: OrderFile[];
+  estado: string;
+  paid: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/ClienteFinal/src/app/core/services/orders-public.service.ts
+++ b/ClienteFinal/src/app/core/services/orders-public.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { Order } from '../models/order.model';
+
+@Injectable({ providedIn: 'root' })
+export class OrdersPublicService {
+  constructor(private http: HttpClient) {}
+
+  submitOrder(form: {
+    nombre: string;
+    telefono: string;
+    files: File[];
+  }): Observable<Order> {
+    const fd = new FormData();
+    fd.append('clienteNombre', form.nombre);
+    fd.append('clienteTelefono', form.telefono);
+    form.files.forEach(f => fd.append('files', f, f.name));
+    return this.http.post<Order>(`${environment.apiUrl}/public/orders`, fd);
+  }
+}

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
@@ -1,20 +1,41 @@
 <div *ngIf="!enviado; else enviadoTpl">
-  <form (ngSubmit)="enviar()" #form="ngForm">
+  <form (ngSubmit)="enviar(form)" #form="ngForm">
     <label>
       Nombre:
       <input type="text" name="nombre" [(ngModel)]="nombre" required />
     </label>
     <label>
       Teléfono:
-      <input type="tel" name="telefono" [(ngModel)]="telefono" required />
+      <input
+        type="tel"
+        name="telefono"
+        [(ngModel)]="telefono"
+        required
+        pattern="\d{6,20}"
+      />
     </label>
     <label>
       Archivos:
-      <input type="file" (change)="onFileChange($event)" multiple />
+      <input
+        type="file"
+        accept="application/pdf"
+        (change)="onFileChange($event)"
+        multiple
+      />
     </label>
-    <button type="submit" [disabled]="loading">Enviar</button>
+    <ul>
+      <li *ngFor="let f of archivos">{{ f.name }} ({{ f.size / 1024 / 1024 | number:'1.2-2' }} MB)</li>
+    </ul>
+    <div *ngFor="let e of fileErrors" class="error">{{ e }}</div>
+    <div *ngIf="errorMsg" class="error">{{ errorMsg }}</div>
+    <button
+      type="submit"
+      [disabled]="loading || form.invalid || archivos.length === 0 || fileErrors.length > 0"
+    >
+      {{ loading ? 'Enviando...' : 'Enviar' }}
+    </button>
   </form>
 </div>
 <ng-template #enviadoTpl>
-  <p>Pedido enviado</p>
+  <p>¡Pedido enviado!</p>
 </ng-template>

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
-import { environment } from '../../../environments/environment';
+import { OrdersPublicService } from '../../core/services/orders-public.service';
 
 @Component({
   selector: 'app-nuevo-pedido',
@@ -14,41 +13,54 @@ export class NuevoPedidoComponent {
   nombre = '';
   telefono = '';
   archivos: File[] = [];
+  fileErrors: string[] = [];
   enviado = false;
   loading = false;
+  errorMsg = '';
 
-  constructor(private http: HttpClient) {}
+  constructor(private ordersService: OrdersPublicService) {}
 
   onFileChange(event: Event): void {
     const target = event.target as HTMLInputElement;
-    this.archivos = Array.from(target.files || []);
+    this.archivos = [];
+    this.fileErrors = [];
+    Array.from(target.files || []).forEach(f => {
+      if (f.type !== 'application/pdf') {
+        this.fileErrors.push(`${f.name} no es un PDF`);
+      } else if (f.size > 15 * 1024 * 1024) {
+        this.fileErrors.push(`${f.name} supera 15MB`);
+      } else {
+        this.archivos.push(f);
+      }
+    });
   }
 
-  async enviar(): Promise<void> {
-    if (!this.nombre || !this.telefono || this.archivos.length === 0) {
+  enviar(form: any): void {
+    this.errorMsg = '';
+    if (form.invalid || this.archivos.length === 0 || this.fileErrors.length) {
       return;
     }
     this.loading = true;
-    try {
-      const formData = new FormData();
-      this.archivos.forEach((f) => formData.append('file', f));
-      const uploaded = await this.http.post<{ nombre: string; path: string; url: string }[]>(
-        `${environment.apiUrl}/orders/upload`,
-        formData
-      ).toPromise();
-      const archivos = uploaded?.map((f) => ({ nombre: f.nombre, url: f.url })) || [];
-      await this.http.post(`${environment.apiUrl}/orders`, {
-        clienteNombre: this.nombre,
-        clienteTelefono: this.telefono,
-        archivos,
-        paid: true,
-      }).toPromise();
-      this.enviado = true;
-      this.nombre = '';
-      this.telefono = '';
-      this.archivos = [];
-    } finally {
-      this.loading = false;
-    }
+    this.ordersService
+      .submitOrder({
+        nombre: this.nombre,
+        telefono: this.telefono,
+        files: this.archivos,
+      })
+      .subscribe({
+        next: order => {
+          this.enviado = true;
+          this.nombre = '';
+          this.telefono = '';
+          this.archivos = [];
+          form.resetForm();
+        },
+        error: () => {
+          this.errorMsg = 'Intenta más tarde';
+        },
+        complete: () => {
+          this.loading = false;
+        },
+      });
   }
 }


### PR DESCRIPTION
## Summary
- add Supabase storage service with bucket creation and file upload helpers
- expose new `/public/orders` endpoint for anonymous order submissions
- implement public order form on client with PDF validation

## Testing
- `cd BackOffice/BackEnd && npm test -- --config jest.config.js --passWithNoTests`
- `cd BackOffice/BackEnd && npm run build`
- `cd ClienteFinal && npm test` *(fails: TS18003 no inputs found)*
- `cd ClienteFinal && npm run build` *(fails: 403 fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bba09894b0832a9b1e5ee1754376ce