### PR TITLE
feat: enable public order submission flow

### DIFF
--- a/BackOffice/BackEnd/README.md
+++ b/BackOffice/BackEnd/README.md
@@ -72,6 +72,7 @@ Variables principales:
 - `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`.
 - `JWT_SECRET`, `JWT_EXPIRES_IN`.
 - `PORT`, `CORS_ORIGIN`.
+  - En producción agrega el origen del front público (ej: `http://localhost:4200`) a `CORS_ORIGIN` si corre en otro puerto.
 
 ### 3. Ejecutar migraciones
 Las migraciones se ejecutan contra la conexión directa (5432):
@@ -154,6 +155,17 @@ npm run test:e2e
 
 # Test coverage
 npm run test:cov
+```
+
+### Probar endpoint público con PowerShell
+
+```powershell
+$form = @{
+  clienteNombre = "Cliente QA"
+  clienteTelefono = "1122334455"
+  files = Get-Item "C:\ruta\archivo1.pdf", "C:\ruta\archivo2.pdf"
+}
+Invoke-RestMethod -Uri http://localhost:3000/public/orders -Method Post -Form $form
 ```
 
 ## 📝 Scripts Disponibles

--- a/BackOffice/BackEnd/src/app.module.ts
+++ b/BackOffice/BackEnd/src/app.module.ts
@@ -5,6 +5,7 @@ import { OrdersModule } from './orders/orders.module';
 import { EmployeesModule } from './employees/employees.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
+import { PublicOrdersModule } from './public-orders/public-orders.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AuthModule } from './auth/auth.module';
     EmployeesModule,
     AuthModule,
     HealthModule,
+    PublicOrdersModule,
   ],
 })
 export class AppModule {}

--- a/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
+++ b/BackOffice/BackEnd/src/public-orders/dto/create-public-order.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreatePublicOrderDto {
+  @ApiProperty({ description: 'Nombre del cliente' })
+  @IsString()
+  clienteNombre: string;
+
+  @ApiProperty({ description: 'Teléfono del cliente' })
+  @IsString()
+  clienteTelefono: string;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'binary',
+    isArray: true,
+    required: false,
+    description: 'Archivos PDF',
+  })
+  files?: any;
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.controller.ts
@@ -1,0 +1,62 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  UploadedFiles,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import { randomUUID } from 'crypto';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+import { OrdersService } from '../orders/orders.service';
+import { CreatePublicOrderDto } from './dto/create-public-order.dto';
+
+@Controller('public/orders')
+export class PublicOrdersController {
+  constructor(
+    private readonly ordersService: OrdersService,
+    private readonly storageService: SupabaseStorageService,
+  ) {}
+
+  @Post()
+  @UseInterceptors(
+    FilesInterceptor('files', 10, {
+      storage: memoryStorage(),
+      limits: { fileSize: 15 * 1024 * 1024 },
+    }),
+  )
+  async create(
+    @Body() body: CreatePublicOrderDto,
+    @UploadedFiles() files: Express.Multer.File[],
+  ) {
+    if (!files || files.length === 0) {
+      throw new BadRequestException('Se requieren archivos');
+    }
+    const invalid = files.find(f => f.mimetype !== 'application/pdf');
+    if (invalid) {
+      throw new BadRequestException('Solo se permiten archivos PDF');
+    }
+
+    await this.storageService.ensureBucket('orders');
+    const archivos = await Promise.all(
+      files.map(async file => {
+        const now = new Date();
+        const folder = `${now.getFullYear()}/${String(
+          now.getMonth() + 1,
+        ).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}`;
+        const path = `${folder}/${randomUUID()}/${file.originalname}`;
+        const { url } = await this.storageService.uploadFile(file, path);
+        return { nombre: file.originalname, url };
+      }),
+    );
+
+    return this.ordersService.createOrder({
+      clienteNombre: body.clienteNombre,
+      clienteTelefono: body.clienteTelefono,
+      archivos,
+      paid: false,
+    });
+  }
+}

--- a/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
+++ b/BackOffice/BackEnd/src/public-orders/public-orders.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PublicOrdersController } from './public-orders.controller';
+import { OrdersService } from '../orders/orders.service';
+import { Order } from '../orders/entities/order.entity';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Order])],
+  controllers: [PublicOrdersController],
+  providers: [OrdersService, SupabaseStorageService],
+})
+export class PublicOrdersModule {}

--- a/ClienteFinal/README.md
+++ b/ClienteFinal/README.md
@@ -90,6 +90,14 @@ npm start
 npm run build
 ```
 
+### Configuración de entorno
+
+Edita `src/environments/environment.ts` y ajusta `apiUrl` si el backend corre en otro host o puerto (por defecto `http://localhost:3000`).
+
+### Enviar un pedido
+
+En la pantalla de nuevo pedido completá nombre, teléfono y seleccioná uno o más PDFs. Al hacer clic en **Enviar pedido** los archivos se envían al backend y se muestra el ID del pedido creado.
+
 ### Comandos Disponibles
 
 - `npm start`: Ejecuta la aplicación en modo desarrollo

--- a/ClienteFinal/src/app/core/services/orders-public.service.ts
+++ b/ClienteFinal/src/app/core/services/orders-public.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface PublicOrder {
+  id: string;
+  clienteNombre: string;
+  clienteTelefono: string;
+  archivos: { nombre: string; url: string }[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class OrdersPublicService {
+  constructor(private http: HttpClient) {}
+
+  submitOrder(form: {
+    nombre: string;
+    telefono: string;
+    files: File[];
+  }): Observable<PublicOrder> {
+    const fd = new FormData();
+    fd.append('clienteNombre', form.nombre);
+    fd.append('clienteTelefono', form.telefono);
+    form.files.forEach(f => fd.append('files', f, f.name));
+    return this.http.post<PublicOrder>(`${environment.apiUrl}/public/orders`, fd);
+  }
+}

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
@@ -6,15 +6,21 @@
     </label>
     <label>
       Teléfono:
-      <input type="tel" name="telefono" [(ngModel)]="telefono" required />
+      <input type="tel" name="telefono" [(ngModel)]="telefono" required pattern="\d{6,20}" />
     </label>
     <label>
       Archivos:
-      <input type="file" (change)="onFileChange($event)" multiple />
+      <input type="file" (change)="onFileChange($event)" multiple accept="application/pdf" required />
     </label>
-    <button type="submit" [disabled]="loading">Enviar</button>
+    <ul>
+      <li *ngFor="let f of archivos">{{ f.name }} ({{ f.size / 1024 | number:'1.0-0' }} KB)</li>
+    </ul>
+    <p *ngIf="error" class="error">{{ error }}</p>
+    <button type="submit" [disabled]="form.invalid || archivos.length === 0 || loading">
+      {{ loading ? 'Enviando...' : 'Enviar pedido' }}
+    </button>
   </form>
 </div>
 <ng-template #enviadoTpl>
-  <p>Pedido enviado</p>
+  <p>¡Pedido enviado! ID: {{ orderId }}</p>
 </ng-template>


### PR DESCRIPTION
## Summary
- add Supabase storage service with ensureBucket and public uploads
- expose unauthenticated `/public/orders` endpoint to store PDFs and create orders
- wire Angular client to upload PDFs and show order confirmation

## Testing
- `npm test` (backend) *(fails: Multiple configurations found)*
- `npm test` (frontend) *(fails: TS18003: No inputs were found)*


------
https://chatgpt.com/codex/tasks/task_e_68bba09894b0832a9b1e5ee1754376ce