### PR TITLE
feat: enable pdf uploads and order listing

### DIFF
--- a/BackOffice/FrontEnd/src/app/core/interceptors/jwt.interceptor.ts
+++ b/BackOffice/FrontEnd/src/app/core/interceptors/jwt.interceptor.ts
@@ -2,13 +2,18 @@ import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { catchError, throwError } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { environment } from '../../../environments/environment';
 
 export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
-  const token = localStorage.getItem('token');
-  const authReq = token ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }) : req;
+  const auth = inject(AuthService);
   const router = inject(Router);
+  const token = auth.token;
+  if (token && req.url.startsWith(environment.apiUrl)) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
 
-  return next(authReq).pipe(
+  return next(req).pipe(
     catchError((err: HttpErrorResponse) => {
       if (err.status === 401) {
         localStorage.removeItem('token');

--- a/BackOffice/FrontEnd/src/app/core/models/pedido.model.ts
+++ b/BackOffice/FrontEnd/src/app/core/models/pedido.model.ts
@@ -13,8 +13,8 @@ export interface Pedido {
 export interface Archivo {
   nombre: string;
   url: string;
-  tamano: number;
-  tipo: string;
+  tamano?: number | null;
+  tipo?: string;
 }
 
 export type EstadoPedido = 'pendiente' | 'procesando' | 'listo' | 'completado';

--- a/BackOffice/FrontEnd/src/app/core/services/pedidos.service.ts
+++ b/BackOffice/FrontEnd/src/app/core/services/pedidos.service.ts
@@ -12,7 +12,7 @@ export class PedidosService {
 
   constructor(private http: HttpClient) {}
 
-  getPedidosPendientes(): Observable<Pedido[]> {
+  getPending(): Observable<Pedido[]> {
     this.isLoading.set(true);
     return this.http
       .get<Pedido[]>(`${environment.apiUrl}/orders`)
@@ -42,6 +42,6 @@ export class PedidosService {
   }
 
   refreshPedidos(): Observable<Pedido[]> {
-    return this.getPedidosPendientes();
+    return this.getPending();
   }
 }

--- a/ClienteFinal/src/app/core/services/orders-public.service.ts
+++ b/ClienteFinal/src/app/core/services/orders-public.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 export interface PublicOrder {
@@ -14,15 +14,21 @@ export interface PublicOrder {
 export class OrdersPublicService {
   constructor(private http: HttpClient) {}
 
-  submitOrder(form: {
+  submitOrder(input: {
     nombre: string;
     telefono: string;
     files: File[];
   }): Observable<PublicOrder> {
     const fd = new FormData();
-    fd.append('clienteNombre', form.nombre);
-    fd.append('clienteTelefono', form.telefono);
-    form.files.forEach(f => fd.append('files', f, f.name));
-    return this.http.post<PublicOrder>(`${environment.apiUrl}/public/orders`, fd);
+    fd.set('clienteNombre', input.nombre);
+    fd.set('clienteTelefono', input.telefono);
+    for (const f of input.files) {
+      fd.append('files', f, f.name);
+    }
+    return this.http
+      .post<PublicOrder>(`${environment.apiUrl}/public/orders`, fd, {
+        observe: 'response',
+      })
+      .pipe(map(r => r.body as PublicOrder));
   }
 }

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
@@ -1,22 +1,22 @@
 <div *ngIf="!enviado; else enviadoTpl">
+  <app-file-upload
+    [archivos]="archivosUI"
+    (archivoAgregado)="archivosUI.push($event)"
+    (archivoEliminado)="onEliminar($event)"
+    (filesSelected)="onFilesSelected($event)"
+  ></app-file-upload>
+
   <form (ngSubmit)="enviar()" #form="ngForm">
     <label>
       Nombre:
-      <input type="text" name="nombre" [(ngModel)]="nombre" required />
+      <input type="text" name="nombre" [(ngModel)]="model.nombre" required />
     </label>
     <label>
       Teléfono:
-      <input type="tel" name="telefono" [(ngModel)]="telefono" required pattern="\d{6,20}" />
+      <input type="tel" name="telefono" [(ngModel)]="model.telefono" required pattern="\d{6,20}" />
     </label>
-    <label>
-      Archivos:
-      <input type="file" (change)="onFileChange($event)" multiple accept="application/pdf" required />
-    </label>
-    <ul>
-      <li *ngFor="let f of archivos">{{ f.name }} ({{ f.size / 1024 | number:'1.0-0' }} KB)</li>
-    </ul>
     <p *ngIf="error" class="error">{{ error }}</p>
-    <button type="submit" [disabled]="form.invalid || archivos.length === 0 || loading">
+    <button type="submit" [disabled]="form.invalid || !files.length || loading">
       {{ loading ? 'Enviando...' : 'Enviar pedido' }}
     </button>
   </form>

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
@@ -2,17 +2,19 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { OrdersPublicService } from '../../core/services/orders-public.service';
+import { Archivo } from '../../core/models/pedido.model';
+import { FileUploadComponent } from '../../shared/components/file-upload/file-upload.component';
 
 @Component({
   selector: 'app-nuevo-pedido',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, FileUploadComponent],
   templateUrl: './nuevo-pedido.component.html'
 })
 export class NuevoPedidoComponent {
-  nombre = '';
-  telefono = '';
-  archivos: File[] = [];
+  archivosUI: Archivo[] = [];
+  files: File[] = [];
+  model = { nombre: '', telefono: '' };
   enviado = false;
   loading = false;
   error: string | null = null;
@@ -20,37 +22,29 @@ export class NuevoPedidoComponent {
 
   constructor(private ordersService: OrdersPublicService) {}
 
-  onFileChange(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    const selected = Array.from(target.files || []);
-    this.archivos = [];
-    this.error = null;
-    selected.forEach(f => {
-      if (f.type !== 'application/pdf') {
-        this.error = 'Solo se permiten archivos PDF';
-      } else if (f.size > 15 * 1024 * 1024) {
-        this.error = 'Cada archivo debe pesar menos de 15MB';
-      } else {
-        this.archivos.push(f);
-      }
-    });
+  onFilesSelected(files: File[]): void {
+    this.files = files;
+  }
+
+  onEliminar(id: string): void {
+    this.archivosUI = this.archivosUI.filter(a => a.id !== id);
   }
 
   enviar(): void {
-    if (!this.nombre || !this.telefono || this.archivos.length === 0 || this.loading) {
+    if (!this.model.nombre || !this.model.telefono || this.files.length === 0 || this.loading) {
       return;
     }
     this.loading = true;
     this.error = null;
     this.ordersService
-      .submitOrder({ nombre: this.nombre, telefono: this.telefono, files: this.archivos })
+      .submitOrder({ nombre: this.model.nombre, telefono: this.model.telefono, files: this.files })
       .subscribe({
         next: order => {
           this.enviado = true;
           this.orderId = order.id;
-          this.nombre = '';
-          this.telefono = '';
-          this.archivos = [];
+          this.model = { nombre: '', telefono: '' };
+          this.archivosUI = [];
+          this.files = [];
         },
         error: () => {
           this.error = 'Intenta más tarde';

--- a/ClienteFinal/src/app/shared/components/file-upload/file-upload.component.html
+++ b/ClienteFinal/src/app/shared/components/file-upload/file-upload.component.html
@@ -10,12 +10,12 @@
     <div class="drop-zone-content">
       <div class="upload-icon">📁</div>
       <h3>Arrastra archivos aquí o haz clic para seleccionar</h3>
-      <p>Soporta PDF, DOC, DOCX, TXT, JPG, PNG</p>
+      <p>Solo PDF (máx 15 MB por archivo)</p>
       <input
         #fileInput
         type="file"
         multiple
-        accept=".pdf,.doc,.docx,.txt,.jpg,.jpeg,.png"
+        accept="application/pdf,.pdf"
         (change)="onFileSelected($event)"
         style="display: none;"
       />

--- a/ClienteFinal/src/environments/environment.ts
+++ b/ClienteFinal/src/environments/environment.ts
@@ -1,5 +1,4 @@
-declare const process: any;
-
 export const environment = {
-  apiUrl: process.env['NG_APP_API_URL'] || 'http://localhost:3000',
+  production: false,
+  apiUrl: 'http://localhost:3000',
 };


### PR DESCRIPTION
## Summary
- allow file upload component to emit selected File objects and restrict input to PDF
- let public order page send file blobs via FormData and point to backend API
- show pending orders with JWT auth, simplified file info and safe links

## Testing
- `npm test` *(ClienteFinal: No inputs were found in config file '/workspace/ftcp---full/ClienteFinal/tsconfig.spec.json')*
- `npm test` *(BackOffice/FrontEnd: ng: not found)*
- `npm test` *(BackOffice/BackEnd: Multiple configurations found)*

------
https://chatgpt.com/codex/tasks/task_e_68be045c2598832a8b348b70509388d4