### PR TITLE
feat: emit selected files and restrict upload to pdf

### DIFF
--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.html
@@ -8,13 +8,12 @@
       Teléfono:
       <input type="tel" name="telefono" [(ngModel)]="telefono" required pattern="\d{6,20}" />
     </label>
-    <label>
-      Archivos:
-      <input type="file" (change)="onFileChange($event)" multiple accept="application/pdf" required />
-    </label>
-    <ul>
-      <li *ngFor="let f of archivos">{{ f.name }} ({{ f.size / 1024 | number:'1.0-0' }} KB)</li>
-    </ul>
+    <app-file-upload
+      [archivos]="archivosMeta"
+      (archivoAgregado)="onArchivoAgregado($event)"
+      (archivoEliminado)="onArchivoEliminado($event)"
+      (filesSelected)="onFilesSelected($event)"
+    ></app-file-upload>
     <p *ngIf="error" class="error">{{ error }}</p>
     <button type="submit" [disabled]="form.invalid || archivos.length === 0 || loading">
       {{ loading ? 'Enviando...' : 'Enviar pedido' }}

--- a/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
+++ b/ClienteFinal/src/app/features/nuevo-pedido/nuevo-pedido.component.ts
@@ -2,17 +2,20 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { OrdersPublicService } from '../../core/services/orders-public.service';
+import { FileUploadComponent } from '../../shared/components/file-upload/file-upload.component';
+import { Archivo } from '../../core/models/pedido.model';
 
 @Component({
   selector: 'app-nuevo-pedido',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, FileUploadComponent],
   templateUrl: './nuevo-pedido.component.html'
 })
 export class NuevoPedidoComponent {
   nombre = '';
   telefono = '';
   archivos: File[] = [];
+  archivosMeta: Archivo[] = [];
   enviado = false;
   loading = false;
   error: string | null = null;
@@ -20,20 +23,16 @@ export class NuevoPedidoComponent {
 
   constructor(private ordersService: OrdersPublicService) {}
 
-  onFileChange(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    const selected = Array.from(target.files || []);
-    this.archivos = [];
-    this.error = null;
-    selected.forEach(f => {
-      if (f.type !== 'application/pdf') {
-        this.error = 'Solo se permiten archivos PDF';
-      } else if (f.size > 15 * 1024 * 1024) {
-        this.error = 'Cada archivo debe pesar menos de 15MB';
-      } else {
-        this.archivos.push(f);
-      }
-    });
+  onFilesSelected(files: File[]): void {
+    this.archivos = files;
+  }
+
+  onArchivoAgregado(archivo: Archivo): void {
+    this.archivosMeta.push(archivo);
+  }
+
+  onArchivoEliminado(id: string): void {
+    this.archivosMeta = this.archivosMeta.filter(a => a.id !== id);
   }
 
   enviar(): void {

--- a/ClienteFinal/src/app/shared/components/file-upload/file-upload.component.html
+++ b/ClienteFinal/src/app/shared/components/file-upload/file-upload.component.html
@@ -10,12 +10,12 @@
     <div class="drop-zone-content">
       <div class="upload-icon">📁</div>
       <h3>Arrastra archivos aquí o haz clic para seleccionar</h3>
-      <p>Soporta PDF, DOC, DOCX, TXT, JPG, PNG</p>
+      <p>Solo PDF (máx 15 MB)</p>
       <input
         #fileInput
         type="file"
         multiple
-        accept=".pdf,.doc,.docx,.txt,.jpg,.jpeg,.png"
+        accept="application/pdf,.pdf"
         (change)="onFileSelected($event)"
         style="display: none;"
       />

--- a/ClienteFinal/src/app/shared/components/file-upload/file-upload.component.ts
+++ b/ClienteFinal/src/app/shared/components/file-upload/file-upload.component.ts
@@ -13,8 +13,10 @@ export class FileUploadComponent {
   @Input() archivos: Archivo[] = [];
   @Output() archivoAgregado = new EventEmitter<Archivo>();
   @Output() archivoEliminado = new EventEmitter<string>();
+  @Output() filesSelected = new EventEmitter<File[]>();
 
   isDragOver = false;
+  private selectedFiles: { id: string; file: File }[] = [];
 
   onDragOver(event: DragEvent): void {
     event.preventDefault();
@@ -49,15 +51,18 @@ export class FileUploadComponent {
 
   private procesarArchivos(files: FileList): void {
     Array.from(files).forEach((file) => {
+      const id = this.generarId();
       const archivo: Archivo = {
-        id: this.generarId(),
+        id,
         nombre: file.name,
         tamano: file.size,
         tipo: file.type || this.obtenerExtension(file.name),
         fechaSubida: new Date(),
       };
       this.archivoAgregado.emit(archivo);
+      this.selectedFiles.push({ id, file });
     });
+    this.filesSelected.emit(this.selectedFiles.map((f) => f.file));
   }
 
   private generarId(): string {
@@ -69,7 +74,9 @@ export class FileUploadComponent {
   }
 
   eliminarArchivo(archivoId: string): void {
+    this.selectedFiles = this.selectedFiles.filter((f) => f.id !== archivoId);
     this.archivoEliminado.emit(archivoId);
+    this.filesSelected.emit(this.selectedFiles.map((f) => f.file));
   }
 
   formatFileSize(bytes: number): string {


### PR DESCRIPTION
## Summary
- track selected file blobs and emit them from file-upload component
- limit uploads to PDF and connect nuevo pedido page to file uploader

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file '/workspace/ftcp---full/ClienteFinal/tsconfig.spec.json')*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68be03bfac4c832ab9f3413499d78415